### PR TITLE
Cleanup and Fixes

### DIFF
--- a/contracts/Resolution.sol
+++ b/contracts/Resolution.sol
@@ -112,7 +112,7 @@ contract Resolution {
             !resolution.hasVoted[account] &&
             !resolution.delegatorHasVoted[account]
         ) {
-            votingPower = voting.getVotesAt(account, resolution.snapshotId);
+            votingPower = voting.getVotingPowerAt(account, resolution.snapshotId);
             if (votingPower == 0) {
                 votingPower = token.balanceOf(account); // TODO: use balanceOfAt as soon as contract available
             }
@@ -127,7 +127,7 @@ contract Resolution {
         ResolutionContent storage resolution
     ) internal {
         if (!resolution.hasVoted[delegate]) {
-            resolution.votes[delegate] = voting.getVotesAt(
+            resolution.votes[delegate] = voting.getVotingPowerAt(
                 delegate,
                 resolution.snapshotId
             );

--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -14,20 +14,20 @@ contract Voting is AccessControl {
     bytes32 private _contributorRole;
 
     mapping(address => address) _delegates;
-    mapping(address => uint256) _votes;
+    mapping(address => uint256) _votingPower;
     mapping(address => uint256) _delegators;
 
     uint256 _totalVotingPower;
 
     event DelegateChanged(
-        address delegator,
+        address indexed delegator,
         address currentDelegate,
         address newDelegate
     );
     event DelegateVotesChanged(
-        address account,
-        uint256 oldVotes,
-        uint256 newVotes
+        address indexed account,
+        uint256 oldVotingPower,
+        uint256 newVotingPower
     );
 
     constructor() {
@@ -70,8 +70,8 @@ contract Voting is AccessControl {
         return _delegates[account];
     }
 
-    function getVotes(address account) public view returns (uint256) {
-        return _votes[account];
+    function getVotingPower(address account) public view returns (uint256) {
+        return _votingPower[account];
     }
 
     function getTotalVotingPower() public view returns (uint256) {
@@ -137,9 +137,9 @@ contract Voting is AccessControl {
         if (from != to && amount > 0) {
             if (from != address(0)) {
                 _beforeMoveVotingPower(from);
-                uint256 oldVotes = _votes[from];
-                _votes[from] = oldVotes - amount;
-                emit DelegateVotesChanged(from, oldVotes, _votes[from]);
+                uint256 oldVotingPower = _votingPower[from];
+                _votingPower[from] = oldVotingPower - amount;
+                emit DelegateVotesChanged(from, oldVotingPower, _votingPower[from]);
             }
             else {
                 _beforeUpdateTotalVotingPower();
@@ -148,9 +148,9 @@ contract Voting is AccessControl {
 
             if (to != address(0)) {
                 _beforeMoveVotingPower(to);
-                uint256 oldVotes = _votes[to];
-                _votes[to] = oldVotes + amount;
-                emit DelegateVotesChanged(to, oldVotes, _votes[to]);
+                uint256 oldVotingPower = _votingPower[to];
+                _votingPower[to] = oldVotingPower + amount;
+                emit DelegateVotesChanged(to, oldVotingPower, _votingPower[to]);
             }
             else {
                 _beforeUpdateTotalVotingPower();

--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -54,6 +54,12 @@ contract Voting is AccessControl {
         _contributorRole = _shareholderRegistry.CONTRIBUTOR_STATUS();
     }
 
+    /// @dev Hook to be called by the companion token upon token transfer
+    /// @notice Only the companion token can call this method
+    /// @notice The voting power transfer logic relies on the correct usage of this hook from the companion token
+    /// @param from The sender's address
+    /// @param to The receiver's address
+    /// @param amount The amount sent
     function afterTokenTransfer(
         address from,
         address to,
@@ -62,18 +68,33 @@ contract Voting is AccessControl {
         _moveVotingPower(getDelegate(from), getDelegate(to), amount);
     }
 
+    /// @dev Returns the account's current delegate
+    /// @param account The account whose delegate is requested
+    /// @return Account's voting power
     function getDelegate(address account) public view returns (address) {
         return _delegates[account];
     }
 
+    /// @dev Returns the amount of valid votes for a given address
+    /// @notice An address that is not a contributor, will have always 0 voting power
+    /// @notice An address that has not delegated at least itself, will have always 0 voting power
+    /// @param account The account whose voting power is requested
+    /// @return Account's voting power
     function getVotingPower(address account) public view returns (uint256) {
         return _votingPower[account];
     }
 
+    /// @dev Returns the total amount of valid votes
+    /// @notice It's the sum of all tokens owned by contributors who has been at least delegated to themselves
+    /// @return Total voting power
     function getTotalVotingPower() public view returns (uint256) {
         return _totalVotingPower;
     }
 
+    /// @dev Allows sender to delegate another address for voting
+    /// @notice The first address to be delegated must be the sender itself
+    /// @notice Sub-delegation is not allowed
+    /// @param newDelegate Destination address of module transaction.
     function delegate(address newDelegate) public {
         require(
             _shareholderRegistry.isAtLeast(_contributorRole, msg.sender),

--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -54,10 +54,6 @@ contract Voting is AccessControl {
         _contributorRole = _shareholderRegistry.CONTRIBUTOR_STATUS();
     }
 
-    function balanceOf(address account) public view returns (uint256) {
-        return _token.balanceOf(account);
-    }
-
     function afterTokenTransfer(
         address from,
         address to,
@@ -119,7 +115,7 @@ contract Voting is AccessControl {
 
         _beforeDelegate(delegator);
 
-        uint256 delegatorBalance = balanceOf(delegator);
+        uint256 delegatorBalance = _token.balanceOf(delegator);
         _delegates[delegator] = newDelegate;
         _delegators[newDelegate] = _delegators[newDelegate] + 1;
         _delegators[currentDelegate] = _delegators[newDelegate] - 1;

--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -64,14 +64,10 @@ contract Voting is AccessControl {
 
         if (delegated != account) {
             _delegate(account, account);
-
-            if (votingPower > 0) {
-                _moveVotingPower(delegated, account, votingPower);
-            }
         }
-        else {
-            _totalVotingPower -= votingPower;
-            _votingPower[account] = 0;
+
+        if (votingPower > 0) {
+            _moveVotingPower(delegated, address(0), votingPower);
         }
     }
 

--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -138,13 +138,17 @@ contract Voting is AccessControl {
             "Voting: the proposed delegate is already your delegate."
         );
 
-        address currentDelegateeDelegate = getDelegate(newDelegate);
-        require(
-            currentDelegateeDelegate == newDelegate ||
-                currentDelegateeDelegate == address(0) ||
-                newDelegate == delegator,
-            "Voting: the proposed delegatee has itself a delegate. No sub-delegations allowed."
-        );
+        if (delegator != newDelegate) {
+            address currentDelegateeDelegate = getDelegate(newDelegate);
+            require(
+                currentDelegateeDelegate != address(0),
+                "Voting: the proposed delegate should delegate itself first."
+            );
+            require(
+                currentDelegateeDelegate == newDelegate,
+                "Voting: the proposed delegatee already has a delegate. No sub-delegations allowed."
+            );
+        }
 
         require(
             _delegators[delegator] <= 1,

--- a/contracts/VotingSnapshot.sol
+++ b/contracts/VotingSnapshot.sol
@@ -20,8 +20,8 @@ contract VotingSnapshot is Voting, Snapshottable {
     }
 
     mapping(address => SnapshotsDelegates) _delegationSnapshots;
-    mapping(address => SnapshotsValues) _votesSnapshots;
-    SnapshotsValues private _votingPowerSnapshots;
+    mapping(address => SnapshotsValues) _votingPowerSnapshots;
+    SnapshotsValues private _totalVotingPowerSnapshots;
 
     function snapshot() public virtual override returns (uint256) {
         return _snapshot();
@@ -38,15 +38,15 @@ contract VotingSnapshot is Voting, Snapshottable {
         return valid ? snapshots.delegates[index] : getDelegate(account);
     }
 
-    function getVotesAt(address account, uint256 snapshotId)
+    function getVotingPowerAt(address account, uint256 snapshotId)
         public
         view
         returns (uint256)
     {
-        SnapshotsValues storage snapshots = _votesSnapshots[account];
+        SnapshotsValues storage snapshots = _votingPowerSnapshots[account];
         (bool valid, uint256 index) = _indexAt(snapshotId, snapshots.ids);
 
-        return valid ? snapshots.values[index] : getVotes(account);
+        return valid ? snapshots.values[index] : getVotingPower(account);
     }
 
     function getTotalVotingPowerAt(uint256 snapshotId)
@@ -56,11 +56,11 @@ contract VotingSnapshot is Voting, Snapshottable {
     {
         (bool valid, uint256 index) = _indexAt(
             snapshotId,
-            _votingPowerSnapshots.ids
+            _totalVotingPowerSnapshots.ids
         );
 
         return
-            valid ? _votingPowerSnapshots.values[index] : getTotalVotingPower();
+            valid ? _totalVotingPowerSnapshots.values[index] : getTotalVotingPower();
     }
 
     /*
@@ -103,11 +103,11 @@ contract VotingSnapshot is Voting, Snapshottable {
 
     function _beforeMoveVotingPower(address account) internal override {
         super._beforeMoveVotingPower(account);
-        _updateSnaphshotValues(_votesSnapshots[account], getVotes(account));
+        _updateSnaphshotValues(_votingPowerSnapshots[account], getVotingPower(account));
     }
 
     function _beforeUpdateTotalVotingPower() internal override {
         super._beforeUpdateTotalVotingPower();
-        _updateSnaphshotValues(_votingPowerSnapshots, getTotalVotingPower());
+        _updateSnaphshotValues(_totalVotingPowerSnapshots, getTotalVotingPower());
     }
 }

--- a/docs/voting.md
+++ b/docs/voting.md
@@ -14,7 +14,7 @@ One of the main components of the TelediskoDAO is the automatic voting and settl
 It boils down to set of rules governing the voting and delegation process. Such rules need to be implemented via a Smart Contract in order to enable to automatic execution of this part of the DAO. 
 ## 3 Specification
 ### 3.1 Rules
-AoA rules:
+### 3.1.1 AoA rules:
 * Only Contributors can vote.
 * A Contributor's voting power equals the amount of TT tokens it owns.
 * A Contributor A can delegate another Contributor B, thus transferring A's voting power to B.
@@ -23,14 +23,21 @@ AoA rules:
 * When a Contributor receives new tokens from any source, its voting power increases by the transferred amount.
 * The total voting power at a given time in the DAO is the sum of the voting power of the individual Contributors.
 
-Additional rules:
+### 3.1.2 Additional rules:
 * A Contributor must first delegate itself to be able to delegate others
 
-### 3.2 Voting.sol
+### 3.2 Voting
 The voting power of an account changes after the following actions:
 * Delegation
 * Token transfer
 * Removal of Contributor status
+
+The following conditions always hold true:
+* A token holder that is not a Contributor, has voting power 0
+* A token holder that is a Contributor who delegated someone else, has voting power 0
+* A token holder that is a Contributor who didn't delegate itself (not someone else), has voting power 0
+* A token holder that is a Contributor who delegated itself and has no delegators, has voting power equal to its TT balance
+* A token holder that is a Contributor who delegated itself and has 1 or more delegators, has voting power equal to its TT balance + the sum of the balance of its delegators
 
 #### 3.2.2 Delegation use cases
 Preconditions: 
@@ -41,7 +48,7 @@ Preconditions:
 Flow:
 1. A delegates B
 2. The balance of A is added as voting power to B.
-3. The balance of A is also removed from the voting power of C.
+3. The balance of A is removed from the voting power of C.
 ---
 Preconditions:
 * Both A and B are Contributors
@@ -51,38 +58,99 @@ Preconditions:
 Flow:
 1. A delegates B, 
 2. The balance of A is added as voting power to B.
-3. The balance of A is also removed from the voting power of A.
+3. The balance of A is removed from the voting power of A.
 ---
 Preconditions:
 * A is a Contributor
 * A has no delegate
 
 1. A delegates A
-2. THe balance of A is added as voting power to A
+2. The balance of A is added as voting power to A
 ---
 In all the following cases, delegation fails:
 * A is delegating B, but A has currently no delegates
-* A is delegating B, but B already has a delegate
-* A is delegating B, but A already has a delegator
+* A is delegating B, but B has currently no delegates
+* A is delegating B, but B already has a delegate different from itself
+* A is delegating B, but A already has a delegator different from itself
 * A is delegating B, but B is not a contributor
 * A is delegating B, but A is not a contributor
-#### 3.2.1 Token transfer
+
+#### 3.2.2 Token transfer use cases
+Preconditions: 
+* Both A and B are self-delegated Contributors
+
+Flow:
+1. A transfers 10 tokens to B.
+2. The voting power of B is increased by 10.
+3. The voting power of A is decreased by 10.
+---
+Preconditions:
+* A is a Contributor
+
+Flow:
+1. The DAO mints 10 tokens to A. 
+2. The voting power of A increases by 10.
+3. The total voting power increases by 10.
+---
+Preconditions:
+* A is a Contributor who delegated X
+* B is a Contributor who delegated Y
+
+Flow:
+1. A transfers 10 tokens to B, 
+2. The voting power of Y is increased by 10.
+3. The voting power of X is decreased by 10.
+---
+Preconditions:
+* A is a self-delegated Contributor
+* B is not a Contributor
+
+Flow:
+1. A transfers 10 tokens to B, 
+2. The voting power of A is decreased by 10.
+3. The total voting power is decreased by 10.
+---
+Preconditions:
+* A is not a Contributor
+* B is a self-delegated Contributor
+
+Flow:
+1. A transfers 10 tokens to B, 
+2. The voting power of B is increased by 10.
+3. The total voting power is increased by 10.
+---
+In the following cases, no voting power is changed
+* A is not a Contributor and sends token to B who is not a Contributor
+* A has no delegate and sends token to B who has no delegate
+* The DAO mints token to A who is not a Contributor
+* The DAO mints token to A who has no delegate
+
+#### 3.2.3 Removal of Contributor status
+Preconditions:
+* A is Contributor
+* A has voting power 10
+
+Flow: 
+1. The DAO removes the Contributor status from A
+2. The voting power of A goes to 0
+3. The total voting power is decreased by 10.
+
+
 ## 4 Rationale
 
-<!-- The rationale fleshes out the specification by describing what motivated
-the design and why particular design decisions were made. It should describe
-alternate designs that were considered and related work, e.g. how the feature
-is supported in other languages. The rationale may also provide evidence of
-consensus within the community, and should discuss important objections or
-concerns raised during discussion.-->
+The logic has been modelled as described mainly to match the requirements of the AoA. 
+
+Additionally, the self-delegation step has been added to the rules.
+The rationale behind this decision is to keep the gas cost for transfer cheaper and to simplify the logic.
+Not having done this would have implied that for each token transfer, we needed to check whether the two parties involved where Contributors (calling an external contract) and then perform the due actions. By making the self-delegation mandatory, instead, we can assume that an account that has a delegate (even if it's a self-delegate) is also a Contributor, because it must have first called the `delegate` function whose access is granted only to Contributors.
+
+This and the rest of the contract has been inspired by `ERC20Vote`, in order not to reinvent the wheel.
 
 ## 5 Implementation
 
-<!--The implementations must be completed before any TIP is given status
-"stable", but it need not be completed before the TIP is accepted. While there
-is merit to the approach of reaching consensus on the TIP and rationale before
-writing code, the principle of "rough consensus and running code" is still
-useful when it comes to resolving many discussions of API details.-->
+Implementation can be found in `Voting.sol`, which contains the base logic, and in `VotingSnapshot.sol`, which add snapshotting capabilities to the original contract.
+
+All scenarios are tested in `Voting.ts` and `VotingSnapshot.ts`.
 
 ## 6 Copyright
 

--- a/docs/voting.md
+++ b/docs/voting.md
@@ -1,0 +1,92 @@
+# Voting and Delegation
+
+## 1 Abstract
+
+This document elaborates the logic behind the voting power distribution and delegation implemented in the TelediskoDAO contracts.
+
+## 2 Motivation
+
+One of the main components of the TelediskoDAO is the automatic voting and settlement of resolutions. The Article of Association of the DAO describes how the voting process for a resolution should be implemented. More in detail:
+
+* it specifies on how the voting power should be distributed among token holders
+* it specifies how the delegation among contributors should work
+
+It boils down to set of rules governing the voting and delegation process. Such rules need to be implemented via a Smart Contract in order to enable to automatic execution of this part of the DAO. 
+## 3 Specification
+### 3.1 Rules
+AoA rules:
+* Only Contributors can vote.
+* A Contributor's voting power equals the amount of TT tokens it owns.
+* A Contributor A can delegate another Contributor B, thus transferring A's voting power to B.
+* A Contributor A cannot delegate another Contributor B if B already delegated someone else.
+* A Contributor A cannot delegate another Contributor if A itself has already been delegated.
+* When a Contributor receives new tokens from any source, its voting power increases by the transferred amount.
+* The total voting power at a given time in the DAO is the sum of the voting power of the individual Contributors.
+
+Additional rules:
+* A Contributor must first delegate itself to be able to delegate others
+
+### 3.2 Voting.sol
+The voting power of an account changes after the following actions:
+* Delegation
+* Token transfer
+* Removal of Contributor status
+
+#### 3.2.2 Delegation use cases
+Preconditions: 
+* Both A and B are Contributors
+* A has a delegate C (who is also a Contributor)
+* B has delegated itself
+
+Flow:
+1. A delegates B
+2. The balance of A is added as voting power to B.
+3. The balance of A is also removed from the voting power of C.
+---
+Preconditions:
+* Both A and B are Contributors
+* A has delegated itself
+* B has delegated itself
+
+Flow:
+1. A delegates B, 
+2. The balance of A is added as voting power to B.
+3. The balance of A is also removed from the voting power of A.
+---
+Preconditions:
+* A is a Contributor
+* A has no delegate
+
+1. A delegates A
+2. THe balance of A is added as voting power to A
+---
+In all the following cases, delegation fails:
+* A is delegating B, but A has currently no delegates
+* A is delegating B, but B already has a delegate
+* A is delegating B, but A already has a delegator
+* A is delegating B, but B is not a contributor
+* A is delegating B, but A is not a contributor
+#### 3.2.1 Token transfer
+## 4 Rationale
+
+<!-- The rationale fleshes out the specification by describing what motivated
+the design and why particular design decisions were made. It should describe
+alternate designs that were considered and related work, e.g. how the feature
+is supported in other languages. The rationale may also provide evidence of
+consensus within the community, and should discuss important objections or
+concerns raised during discussion.-->
+
+## 5 Implementation
+
+<!--The implementations must be completed before any TIP is given status
+"stable", but it need not be completed before the TIP is accepted. While there
+is merit to the approach of reaching consensus on the TIP and rationale before
+writing code, the principle of "rough consensus and running code" is still
+useful when it comes to resolving many discussions of API details.-->
+
+## 6 Copyright
+
+<!--All TIPs MUST be released to the public domain.-->
+
+Copyright and related rights waived via
+[CC0](https://creativecommons.org/publicdomain/zero/1.0/)

--- a/test/VotingSnapshot.ts
+++ b/test/VotingSnapshot.ts
@@ -230,7 +230,7 @@ describe("VotingSnapshot", () => {
     describe("getVotesAt", async () => {
       it("reverts with snapshot id of 0", async () => {
         await expect(
-          votingSnapshot.getVotesAt(noDelegate.address, 0)
+          votingSnapshot.getVotingPowerAt(noDelegate.address, 0)
         ).revertedWith("Snapshottable: id is 0");
       });
 
@@ -243,10 +243,10 @@ describe("VotingSnapshot", () => {
         let snapshotIdAfter = await votingSnapshot.getCurrentSnapshotId();
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdBefore)
         ).equal(10);
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdAfter)
         ).equal(21);
       });
 
@@ -260,17 +260,17 @@ describe("VotingSnapshot", () => {
         let snapshotIdAfter = await votingSnapshot.getCurrentSnapshotId();
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdBefore)
         ).equal(0);
         expect(
-          await votingSnapshot.getVotesAt(delegator2.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegator2.address, snapshotIdBefore)
         ).equal(10);
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdAfter)
         ).equal(10);
         expect(
-          await votingSnapshot.getVotesAt(delegator2.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegator2.address, snapshotIdAfter)
         ).equal(0);
       });
 
@@ -283,17 +283,17 @@ describe("VotingSnapshot", () => {
         let snapshotIdAfter = await votingSnapshot.getCurrentSnapshotId();
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdBefore)
         ).equal(10);
         expect(
-          await votingSnapshot.getVotesAt(delegated1.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegated1.address, snapshotIdBefore)
         ).equal(0);
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdAfter)
         ).equal(0);
         expect(
-          await votingSnapshot.getVotesAt(delegated1.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegated1.address, snapshotIdAfter)
         ).equal(10);
       });
 
@@ -310,20 +310,20 @@ describe("VotingSnapshot", () => {
         let snapshotIdAfter = await votingSnapshot.getCurrentSnapshotId();
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdBefore)
         ).equal(10);
         expect(
-          await votingSnapshot.getVotesAt(
+          await votingSnapshot.getVotingPowerAt(
             nonContributor.address,
             snapshotIdBefore
           )
         ).equal(0);
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdAfter)
         ).equal(10);
         expect(
-          await votingSnapshot.getVotesAt(
+          await votingSnapshot.getVotingPowerAt(
             nonContributor.address,
             snapshotIdAfter
           )
@@ -339,20 +339,20 @@ describe("VotingSnapshot", () => {
         let snapshotIdAfter = await votingSnapshot.getCurrentSnapshotId();
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdBefore)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdBefore)
         ).equal(10);
         expect(
-          await votingSnapshot.getVotesAt(
+          await votingSnapshot.getVotingPowerAt(
             nonContributor.address,
             snapshotIdBefore
           )
         ).equal(0);
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotIdAfter)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotIdAfter)
         ).equal(0);
         expect(
-          await votingSnapshot.getVotesAt(
+          await votingSnapshot.getVotingPowerAt(
             nonContributor.address,
             snapshotIdAfter
           )
@@ -366,7 +366,7 @@ describe("VotingSnapshot", () => {
         let snapshotId = await votingSnapshot.getCurrentSnapshotId();
 
         expect(
-          await votingSnapshot.getVotesAt(delegator1.address, snapshotId)
+          await votingSnapshot.getVotingPowerAt(delegator1.address, snapshotId)
         ).equal(42);
       });
     });

--- a/test/voting.ts
+++ b/test/voting.ts
@@ -291,21 +291,21 @@ describe("Voting", () => {
     it("should have as many votes as the balance of the account if not delegate exists", async () => {
       await token.mint(delegator1.address, 10);
 
-      expect(await voting.getVotes(delegator1.address)).equals(10);
+      expect(await voting.getVotingPower(delegator1.address)).equals(10);
     });
 
     it("should increase voting power after minting new tokens", async () => {
       await token.mint(delegator1.address, 10);
       await token.mint(delegator1.address, 21);
 
-      expect(await voting.getVotes(delegator1.address)).equals(31);
+      expect(await voting.getVotingPower(delegator1.address)).equals(31);
     });
 
     it("should transfer all votes to the delegatee upon delegation", async () => {
       await token.mint(delegator1.address, 10);
       await voting.connect(delegator1).delegate(delegated1.address);
 
-      expect(await voting.getVotes(delegated1.address)).equals(10);
+      expect(await voting.getVotingPower(delegated1.address)).equals(10);
     });
 
     it("should remove all votes from the delegatee upon token transfer", async () => {
@@ -313,7 +313,7 @@ describe("Voting", () => {
       await voting.connect(delegator1).delegate(delegated1.address);
       await token.connect(delegator1).transfer(delegated2.address, 10);
 
-      expect(await voting.getVotes(delegated1.address)).equals(0);
+      expect(await voting.getVotingPower(delegated1.address)).equals(0);
     });
 
     it("should move as many votes as tokens transferred to the existing delegatee if delegator receives new tokens", async () => {
@@ -322,14 +322,14 @@ describe("Voting", () => {
       await voting.connect(delegator1).delegate(delegated1.address);
       await token.connect(noDelegate).transfer(delegator1.address, 15);
 
-      expect(await voting.getVotes(delegated1.address)).equals(25);
+      expect(await voting.getVotingPower(delegated1.address)).equals(25);
     });
 
     it("should have 0 votes after delegating", async () => {
       await token.mint(delegator1.address, 10);
       await voting.connect(delegator1).delegate(delegated1.address);
 
-      expect(await voting.getVotes(delegator1.address)).equals(0);
+      expect(await voting.getVotingPower(delegator1.address)).equals(0);
     });
 
     it("should have as many votes as the balance after retransfering delegation to itself", async () => {
@@ -337,27 +337,27 @@ describe("Voting", () => {
       await voting.connect(delegator1).delegate(delegated1.address);
       await voting.connect(delegator1).delegate(delegator1.address);
 
-      expect(await voting.getVotes(delegator1.address)).equals(10);
+      expect(await voting.getVotingPower(delegator1.address)).equals(10);
     });
 
     it("should not increase voting power if a contributor sends tokens to a non contributor", async () => {
       await token.mint(delegator1.address, 10);
       await token.connect(delegator1).transfer(nonContributor.address, 10);
 
-      expect(await voting.getVotes(nonContributor.address)).equals(0);
+      expect(await voting.getVotingPower(nonContributor.address)).equals(0);
     });
 
     it("should increase voting power if a non contributor sends tokens to a contributor", async () => {
       await token.mint(nonContributor.address, 10);
       await token.connect(nonContributor).transfer(delegator1.address, 10);
 
-      expect(await voting.getVotes(delegator1.address)).equals(10);
+      expect(await voting.getVotingPower(delegator1.address)).equals(10);
     });
 
     it("should not increase voting power if a non contributor is given tokens", async () => {
       await token.mint(nonContributor.address, 10);
 
-      expect(await voting.getVotes(nonContributor.address)).equals(0);
+      expect(await voting.getVotingPower(nonContributor.address)).equals(0);
     });
 
     it("should emit 2 events with old and new balances of source and destination addresses", async () => {

--- a/test/voting.ts
+++ b/test/voting.ts
@@ -281,7 +281,7 @@ describe("Voting", () => {
       await expect(
         voting.connect(delegator2).delegate(delegator1.address)
       ).revertedWith(
-        "Voting: the proposed delegatee has itself a delegate. No sub-delegations allowed."
+        "Voting: the proposed delegatee already has a delegate. No sub-delegations allowed."
       );
     });
 
@@ -305,6 +305,12 @@ describe("Voting", () => {
       await expect(
         voting.connect(delegator1).delegate(nonContributor.address)
       ).revertedWith("Voting: only contributors can be delegated.");
+    });
+
+    it("should throw an error when delegating a contributor that has not delegated itself first", async () => {
+      await expect(
+        voting.connect(delegator1).delegate(noDelegate.address)
+      ).revertedWith("Voting: the proposed delegate should delegate itself first.");
     });
 
     it("should emit an event", async () => {


### PR DESCRIPTION
- Add a method to remove the Contributor status from an account, hence modifying the total voting power and the voting power of the account itself. The method is supposed to be called by `Resolution.sol` after the resolution for demoting a Contributor has been passed.  
- `votes` has been renamed to `votingPower` throughout the whole hierarchy, in order make it less ambiguous
- Add a document describing the use cases and flows of the Voting logic
- Fix a bug that would allow someone to delegate an account who is not self-delegated (hence bringing to inconsistencies)