### PR TITLE
Voting allowance logic

### DIFF
--- a/contracts/Resolution/Resolution.sol
+++ b/contracts/Resolution/Resolution.sol
@@ -173,7 +173,7 @@ contract ResolutionManager {
         hasVoted = resolution.hasVoted[voter];
 
         if (
-            _voting.getDelegateAt(voter, resolution.snapshotId) != address(0) &&
+            _voting.getDelegateAt(voter, resolution.snapshotId) != voter &&
             hasVoted
         ) {
             votingPower = _telediskoToken.balanceOfAt(
@@ -272,7 +272,7 @@ contract ResolutionManager {
 
         // If sender has a delegate load voting power from TelediskoToken
         // TODO: change address(0) to msg.address (a voter cannot have delegate 0, only itself or someoneelse)
-        if (delegate != address(0)) {
+        if (delegate != msg.sender) {
             votingPower = _telediskoToken.balanceOfAt(
                 msg.sender,
                 resolution.snapshotId

--- a/contracts/Resolution/Resolution.sol
+++ b/contracts/Resolution/Resolution.sol
@@ -168,7 +168,8 @@ contract ResolutionManager {
         )
     {
         Resolution storage resolution = resolutions[resolutionId];
-
+        require(_voting.canVoteAt(voter, resolution.snapshotId), "Resolution: account could not vote resolution");
+        
         isYes = resolution.hasVotedYes[voter];
         hasVoted = resolution.hasVoted[voter];
 
@@ -242,6 +243,8 @@ contract ResolutionManager {
 
     function vote(uint256 resolutionId, bool isYes) public {
         Resolution storage resolution = resolutions[resolutionId];
+        require(_voting.canVoteAt(msg.sender, resolution.snapshotId), "Resolution: account cannot vote");
+        
         ResolutionType storage resolutionType = resolutionTypes[
             resolution.resolutionTypeId
         ];

--- a/contracts/Resolution/Resolution.sol
+++ b/contracts/Resolution/Resolution.sol
@@ -271,7 +271,6 @@ contract ResolutionManager {
         );
 
         // If sender has a delegate load voting power from TelediskoToken
-        // TODO: change address(0) to msg.address (a voter cannot have delegate 0, only itself or someoneelse)
         if (delegate != msg.sender) {
             votingPower = _telediskoToken.balanceOfAt(
                 msg.sender,

--- a/contracts/Voting/IVoting.sol
+++ b/contracts/Voting/IVoting.sol
@@ -20,6 +20,13 @@ interface IVoting is ISnapshot {
         view
         returns (address);
 
+    function canVote(address account) external view returns (bool);
+
+    function canVoteAt(address account, uint256 snapshotId)
+        external
+        view
+        returns (bool);
+
     function getVotingPower(address account) external view returns (uint256);
 
     function getVotingPowerAt(address account, uint256 snapshotId)

--- a/contracts/Voting/Voting.sol
+++ b/contracts/Voting/Voting.sol
@@ -45,6 +45,10 @@ contract Voting is AccessControl {
         _;
     }
 
+    function canVote(address account) public view returns (bool) {
+        return getDelegate(account) != address(0);
+    }
+
     function setToken(IERC20 token) external onlyRole(MANAGER_ROLE) {
         _token = token;
     }
@@ -66,7 +70,10 @@ contract Voting is AccessControl {
             if (delegated != account) {
                 _delegate(account, account);
             }
-
+            else {
+                _beforeDelegate(account);
+            }
+            
             delete _delegates[account];
 
             uint256 individualVotingPower = _token.balanceOf(account);

--- a/contracts/Voting/VotingSnapshot.sol
+++ b/contracts/Voting/VotingSnapshot.sol
@@ -43,6 +43,17 @@ contract VotingSnapshot is Voting, Snapshottable {
         return valid ? snapshots.delegates[index] : getDelegate(account);
     }
 
+    function canVoteAt(address account, uint256 snapshotId)
+        public
+        view
+        returns (bool)
+    {
+        SnapshotsDelegates storage snapshots = _delegationSnapshots[account];
+        (bool valid, uint256 index) = _indexAt(snapshotId, snapshots.ids);
+
+        return valid ? snapshots.delegates[index] != address(0) : canVote(account);
+    }
+
     function getVotingPowerAt(address account, uint256 snapshotId)
         public
         view

--- a/contracts/mocks/VotingMock.sol
+++ b/contracts/mocks/VotingMock.sol
@@ -15,6 +15,8 @@ contract VotingMock {
 
     mapping(address => address) mockResult_getDelegateAt;
     mapping(address => uint256) mockResult_getVotingPowerAt;
+    mapping(address => bool) mockResult_canVoteAt;
+
     uint256 mockResult_getTotalVotingPowerAt;
 
     function mock_getDelegateAt(address account, address mockResult) public {
@@ -29,12 +31,24 @@ contract VotingMock {
         mockResult_getTotalVotingPowerAt = mockResult;
     }
 
+    function mock_canVoteAt(address account, bool mockResult) public {
+        mockResult_canVoteAt[account] = mockResult;
+    }
+
     function getDelegateAt(address account, uint256)
         public
         view
         returns (address)
     {
         return mockResult_getDelegateAt[account];
+    }
+
+    function canVoteAt(address account, uint256)
+        public
+        view
+        returns (bool)
+    {
+        return mockResult_canVoteAt[account];
     }
 
     function getVotingPowerAt(address account, uint256)

--- a/test/Resolution.ts
+++ b/test/Resolution.ts
@@ -70,6 +70,8 @@ describe("Resolution", () => {
       token.address,
       voting.address
     );
+
+    voting.mock_getDelegateAt(user1.address, user1.address);
   });
 
   let resolutionId: number;
@@ -168,14 +170,14 @@ describe("Resolution", () => {
     });
 
     it("should emit a specific event when there is a new YES vote", async () => {
-      expect(await resolution.vote(resolutionId, true)).emit(
+      expect(await resolution.connect(user1).vote(resolutionId, true)).emit(
         resolution,
         "ResolutionVoted"
       );
     });
 
     it("should emit a specific event when there is a new NO vote", async () => {
-      expect(await resolution.vote(resolutionId, false)).emit(
+      expect(await resolution.connect(user1).vote(resolutionId, false)).emit(
         resolution,
         "ResolutionVoted"
       );
@@ -203,17 +205,17 @@ describe("Resolution", () => {
     */
 
     it("should not allow to vote YES a second time", async () => {
-      await resolution.vote(resolutionId, true);
-      await expect(resolution.vote(resolutionId, true)).revertedWith(
-        "Resolution: can't repeat same vote"
-      );
+      await resolution.connect(user1).vote(resolutionId, true);
+      await expect(
+        resolution.connect(user1).vote(resolutionId, true)
+      ).revertedWith("Resolution: can't repeat same vote");
     });
 
     it("should not allow to vote NO a second time", async () => {
-      await resolution.vote(resolutionId, false);
-      await expect(resolution.vote(resolutionId, false)).revertedWith(
-        "Resolution: can't repeat same vote"
-      );
+      await resolution.connect(user1).vote(resolutionId, false);
+      await expect(
+        resolution.connect(user1).vote(resolutionId, false)
+      ).revertedWith("Resolution: can't repeat same vote");
     });
 
     describe("single voting without delegation", async () => {
@@ -339,6 +341,7 @@ describe("Resolution", () => {
       describe("delegate votes first", async () => {
         async function _prepare(delegateVote: boolean, userVote: boolean) {
           // setup delegation and voting power
+          await voting.mock_getDelegateAt(delegate1.address, delegate1.address);
           await voting.mock_getVotingPowerAt(
             delegate1.address,
             delegateVotingPower
@@ -381,6 +384,7 @@ describe("Resolution", () => {
       describe("user votes first", async () => {
         async function _prepare(userVote: boolean, delegateVote: boolean) {
           // setup delegation and voting power
+          await voting.mock_getDelegateAt(delegate1.address, delegate1.address);
           await voting.mock_getVotingPowerAt(user1.address, 0); // because the power is transferred to the delegate
           await token.mock_balanceOfAt(user1.address, userBalance);
           await voting.mock_getDelegateAt(user1.address, delegate1.address);
@@ -458,6 +462,7 @@ describe("Resolution", () => {
           user.address,
           votingPowers[user.address]
         );
+        await voting.mock_getDelegateAt(user.address, user.address);
         await resolution.connect(user).vote(resolutionId, isYes);
       }
 
@@ -555,6 +560,7 @@ describe("Resolution", () => {
       const votingPowerDelegate = 17 + balanceUser1 + balanceUser2;
 
       beforeEach(async () => {
+        await voting.mock_getDelegateAt(delegate1.address, delegate1.address);
         await voting.mock_getDelegateAt(user1.address, delegate1.address);
         await voting.mock_getDelegateAt(user2.address, delegate1.address);
         await voting.mock_getVotingPowerAt(user1.address, 0);

--- a/test/voting.ts
+++ b/test/voting.ts
@@ -11,7 +11,6 @@ import {
   ShareholderRegistryMock__factory,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import exp from "constants";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);

--- a/test/voting.ts
+++ b/test/voting.ts
@@ -446,6 +446,28 @@ describe("Voting", () => {
     });
   });
 
+  describe("canVote", async () => {
+    it("should allow voting to accounts that have a delegate", async () => {
+      const result = await voting.canVote(delegator1.address);
+
+      expect(result).equal(true);
+    });
+
+    it("not should allow voting to accounts that don't have a delegate", async () => {
+      const result = await voting.canVote(noDelegate.address);
+
+      expect(result).equal(false);
+    });
+
+    it("should not allow voting when contributor removed", async () => {
+      await voting.afterRemoveContributor(delegator1.address);
+
+      const result = await voting.canVote(delegator1.address);
+
+      expect(result).equal(false);
+    });
+  });
+
   describe("complex flows", async () => {
     it("when a non self-delegated contributor is removed of its status, its delegate can again delegate someone else", async () => {
       await voting.connect(delegator1).delegate(delegated1.address);
@@ -594,8 +616,8 @@ describe("Voting", () => {
       await token.mint(delegator1.address, 10);
       await token.mint(delegated1.address, 8);
       await voting.connect(delegator1).delegate(delegated1.address);
-      expect(await voting.getVotingPower(delegator1.address)).equal(0); 
-      expect(await voting.getVotingPower(delegated1.address)).equal(18); 
+      expect(await voting.getVotingPower(delegator1.address)).equal(0);
+      expect(await voting.getVotingPower(delegated1.address)).equal(18);
 
       await shareholderRegistry.setNonContributor(delegator1.address);
       await voting.afterRemoveContributor(delegator1.address);
@@ -603,7 +625,7 @@ describe("Voting", () => {
       await shareholderRegistry.setNonContributor(nonContributor.address);
       await voting.connect(delegator1).delegate(delegator1.address);
 
-      expect(await voting.getVotingPower(delegator1.address)).equal(10);      
+      expect(await voting.getVotingPower(delegator1.address)).equal(10);
       expect(await voting.getVotingPower(delegated1.address)).equal(8);
     });
 
@@ -611,19 +633,18 @@ describe("Voting", () => {
       await token.mint(delegator1.address, 10);
       await token.mint(delegated1.address, 8);
       await voting.connect(delegator1).delegate(delegated1.address);
-      expect(await voting.getTotalVotingPower()).equal(18); 
-      
+      expect(await voting.getTotalVotingPower()).equal(18);
+
       await shareholderRegistry.setNonContributor(delegated1.address);
       await voting.afterRemoveContributor(delegated1.address);
-      expect(await voting.getTotalVotingPower()).equal(10); 
+      expect(await voting.getTotalVotingPower()).equal(10);
 
       await token.mint(delegator1.address, 2);
-      expect(await voting.getTotalVotingPower()).equal(12); 
+      expect(await voting.getTotalVotingPower()).equal(12);
 
       await shareholderRegistry.setNonContributor(nonContributor.address);
       await voting.connect(delegated1).delegate(delegated1.address);
-      expect(await voting.getTotalVotingPower()).equal(20); 
-
+      expect(await voting.getTotalVotingPower()).equal(20);
     });
   });
 });


### PR DESCRIPTION
Additions:
- Voting now has the central knowledge of whether someone can vote or not
- Resolution is extended to allow only allowed voters to vote and to allow retrieval of voting stats only for allowed voters

Fixes:
- Voting was not taking a correct snapshot upon contributor removal. Specifically, a contributor could have both a regular delegate and a 0 address delegate for the same snapshot id
- Resolution tests were flaky due to some collisions with the manually set block ids. A workaround has been applied.