### PR TITLE
Move Roles inside a library

### DIFF
--- a/contracts/ShareholderRegistry/ShareholderRegistry.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistry.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.0;
 
 import "./ShareholderRegistrySnapshot.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
+import { Roles } from "../extensions/Roles.sol";
 
 contract ShareholderRegistry is ShareholderRegistrySnapshot, AccessControl {
     // Benjamin takes all the decisions in first months, assuming the role of
     // the "Resolution", to then delegate to the resolution contract what comes
     // next.
     // This is what zodiac calls "incremental decentralization".
-    bytes32 public MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
     constructor(string memory name, string memory symbol)
         ShareholderRegistrySnapshot(name, symbol)
@@ -21,7 +21,7 @@ contract ShareholderRegistry is ShareholderRegistrySnapshot, AccessControl {
     function snapshot()
         public
         override
-        onlyRole(MANAGER_ROLE)
+        onlyRole(Roles.MANAGER_ROLE)
         returns (uint256)
     {
         return _snapshot();
@@ -29,14 +29,14 @@ contract ShareholderRegistry is ShareholderRegistrySnapshot, AccessControl {
 
     function setStatus(bytes32 status, address account)
         public
-        onlyRole(MANAGER_ROLE)
+        onlyRole(Roles.MANAGER_ROLE)
     {
         _setStatus(status, account);
     }
 
     function mint(address account, uint256 amount)
         public
-        onlyRole(MANAGER_ROLE)
+        onlyRole(Roles.MANAGER_ROLE)
     {
         _mint(account, amount);
     }

--- a/contracts/TelediskoToken/TelediskoToken.sol
+++ b/contracts/TelediskoToken/TelediskoToken.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "./TelediskoTokenSnapshot.sol";
+import { Roles } from "../extensions/Roles.sol";
 
 contract TelediskoToken is TelediskoTokenSnapshot, AccessControl {
     bytes32 public MANAGER_ROLE = keccak256("MANAGER_ROLE");
@@ -16,7 +17,7 @@ contract TelediskoToken is TelediskoTokenSnapshot, AccessControl {
     function setVoting(IVoting voting)
         external
         override
-        onlyRole(MANAGER_ROLE)
+        onlyRole(Roles.MANAGER_ROLE)
     {
         _setVoting(voting);
     }
@@ -24,12 +25,16 @@ contract TelediskoToken is TelediskoTokenSnapshot, AccessControl {
     function setShareholderRegistry(IShareholderRegistry shareholderRegistry)
         external
         override
-        onlyRole(MANAGER_ROLE)
+        onlyRole(Roles.MANAGER_ROLE)
     {
         _setShareholderRegistry(shareholderRegistry);
     }
 
-    function mint(address to, uint256 amount) public override onlyRole(RESOLUTION_ROLE) {
+    function mint(address to, uint256 amount)
+        public
+        override
+        onlyRole(Roles.RESOLUTION_ROLE)
+    {
         _mint(to, amount);
     }
 }

--- a/contracts/TelediskoToken/TelediskoToken.sol
+++ b/contracts/TelediskoToken/TelediskoToken.sol
@@ -7,9 +7,6 @@ import "./TelediskoTokenSnapshot.sol";
 import { Roles } from "../extensions/Roles.sol";
 
 contract TelediskoToken is TelediskoTokenSnapshot, AccessControl {
-    bytes32 public MANAGER_ROLE = keccak256("MANAGER_ROLE");
-    bytes32 public RESOLUTION_ROLE = keccak256("RESOLUTION_ROLE");
-
     constructor(string memory name, string memory symbol)
         TelediskoTokenSnapshot(name, symbol)
     {}

--- a/contracts/Voting/Voting.sol
+++ b/contracts/Voting/Voting.sol
@@ -5,11 +5,9 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "../ShareholderRegistry/IShareholderRegistry.sol";
 import "./IVoting.sol";
+import { Roles } from "../extensions/Roles.sol";
 
 contract Voting is AccessControl {
-    bytes32 public MANAGER_ROLE = keccak256("MANAGER_ROLE");
-    bytes32 public RESOLUTION_ROLE = keccak256("RESOLUTION_ROLE");
-
     IShareholderRegistry _shareholderRegistry;
     IERC20 _token;
 
@@ -49,13 +47,13 @@ contract Voting is AccessControl {
         return getDelegate(account) != address(0);
     }
 
-    function setToken(IERC20 token) external onlyRole(MANAGER_ROLE) {
+    function setToken(IERC20 token) external onlyRole(Roles.MANAGER_ROLE) {
         _token = token;
     }
 
     function setShareholderRegistry(IShareholderRegistry shareholderRegistry)
         external
-        onlyRole(MANAGER_ROLE)
+        onlyRole(Roles.MANAGER_ROLE)
     {
         _shareholderRegistry = shareholderRegistry;
         _contributorRole = _shareholderRegistry.CONTRIBUTOR_STATUS();
@@ -63,7 +61,7 @@ contract Voting is AccessControl {
 
     function beforeRemoveContributor(address account)
         external
-        onlyRole(RESOLUTION_ROLE)
+        onlyRole(Roles.RESOLUTION_ROLE)
     {
         address delegated = getDelegate(account);
         if (delegated != address(0)) {

--- a/contracts/extensions/Roles.sol
+++ b/contracts/extensions/Roles.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+library Roles {
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+    bytes32 public constant RESOLUTION_ROLE = keccak256("RESOLUTION_ROLE");
+}

--- a/test/ResolutionManager.ts
+++ b/test/ResolutionManager.ts
@@ -85,7 +85,7 @@ describe("Resolution", () => {
   });
 
   describe("reading logic", async () => {
-    it.only("returns all resolution types", async () => {
+    it("returns all resolution types", async () => {
       const resolutionTypes = await resolution.getResolutionTypes();
 
       expect(resolutionTypes.length).equal(7);

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -7,7 +7,8 @@ import {
   ShareholderRegistry__factory,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import { parseEther } from "ethers/lib/utils";
+import { parseEther, RLP } from "ethers/lib/utils";
+import { roles } from "./utils/roles";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);
@@ -41,7 +42,7 @@ describe("Shareholder Registry", () => {
     registry = await ShareholderRegistryFactory.deploy("TS", "Teledisko Share");
     await registry.deployed();
 
-    MANAGER_ROLE = await registry.MANAGER_ROLE();
+    MANAGER_ROLE = await roles.MANAGER_ROLE();
 
     SHAREHOLDER_STATUS = await registry.SHAREHOLDER_STATUS();
     INVESTOR_STATUS = await registry.INVESTOR_STATUS();

--- a/test/TelediskoTokenBase.ts
+++ b/test/TelediskoTokenBase.ts
@@ -11,7 +11,6 @@ import {
   VotingMock__factory,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
-import exp from "constants";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);

--- a/test/VotingSnapshot.ts
+++ b/test/VotingSnapshot.ts
@@ -11,6 +11,7 @@ import {
   ShareholderRegistryMock__factory,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { roles } from "./utils/roles";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);
@@ -57,7 +58,7 @@ describe("VotingSnapshot", () => {
     )) as ShareholderRegistryMock__factory;
 
     votingSnapshot = await VotingSnapshotFactory.deploy();
-    managerRole = await votingSnapshot.MANAGER_ROLE();
+    managerRole = await roles.MANAGER_ROLE();
     votingSnapshot.grantRole(managerRole, deployer.address);
 
     token = await ERC20MockFactory.deploy(votingSnapshot.address);
@@ -154,7 +155,7 @@ describe("VotingSnapshot", () => {
       });
 
       it("should return no delegate from a new snapshot if contributor removed", async () => {
-        const resolutionRole = await votingSnapshot.RESOLUTION_ROLE();
+        const resolutionRole = await roles.RESOLUTION_ROLE();
         await votingSnapshot.grantRole(resolutionRole, deployer.address);
         await votingSnapshot.snapshot();
         let snapshotIdBefore = await votingSnapshot.getCurrentSnapshotId();
@@ -278,7 +279,7 @@ describe("VotingSnapshot", () => {
       });
 
       it("should return false when contributor is not anymore a contributor at a given snapshot", async () => {
-        const resolutionRole = await votingSnapshot.RESOLUTION_ROLE();
+        const resolutionRole = await roles.RESOLUTION_ROLE();
         await votingSnapshot.grantRole(resolutionRole, deployer.address);
         await votingSnapshot.snapshot();
         let snapshotIdBefore = await votingSnapshot.getCurrentSnapshotId();

--- a/test/utils/roles.ts
+++ b/test/utils/roles.ts
@@ -1,0 +1,17 @@
+import { ethers } from "hardhat";
+import { Roles, Roles__factory } from "../../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+export let roles: Roles;
+
+before(async () => {
+  let deployer: SignerWithAddress;
+  [deployer] = await ethers.getSigners();
+
+  const RolesFactory = (await ethers.getContractFactory(
+    "Roles",
+    deployer
+  )) as Roles__factory;
+  roles = await RolesFactory.deploy();
+  await roles.deployed();
+});

--- a/test/voting.ts
+++ b/test/voting.ts
@@ -9,8 +9,11 @@ import {
   ERC20Mock__factory,
   ShareholderRegistryMock,
   ShareholderRegistryMock__factory,
+  Roles,
+  Roles__factory,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { roles } from "./utils/roles";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);
@@ -62,8 +65,9 @@ describe("Voting", () => {
     shareholderRegistry = await ShareholderRegistryFactory.deploy();
 
     await voting.deployed();
-    managerRole = await voting.MANAGER_ROLE();
-    resolutionRole = await voting.RESOLUTION_ROLE();
+
+    managerRole = await roles.MANAGER_ROLE();
+    resolutionRole = await roles.RESOLUTION_ROLE();
     voting.grantRole(managerRole, deployer.address);
     voting.grantRole(resolutionRole, deployer.address);
 

--- a/test/voting.ts
+++ b/test/voting.ts
@@ -9,8 +9,6 @@ import {
   ERC20Mock__factory,
   ShareholderRegistryMock,
   ShareholderRegistryMock__factory,
-  Roles,
-  Roles__factory,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { roles } from "./utils/roles";


### PR DESCRIPTION
- Roles were used almost everywhere, therefore it felt necessary having a common place for them
- Tests have been refactored to be able to easily include roles in each test without boilerplate