### PR TITLE
Fix delegation removal upon demotion

### DIFF
--- a/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
@@ -73,7 +73,7 @@ contract ShareholderRegistryBase is ERC20 {
         internal
         virtual
     {
-        if (status != CONTRIBUTOR_STATUS || status != FOUNDER_STATUS) {
+        if (!_isAtLeast(1, status, CONTRIBUTOR_STATUS)) {
             _voting.beforeRemoveContributor(account);
         }
     }

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -157,7 +157,7 @@ describe("Shareholder Registry", () => {
         .to.emit(voting, "BeforeRemoveContributor")
         .withArgs(alice.address);
     });
-    it("should notify the Voting contract when status updated to investor", async () => {
+    it.only("should notify the Voting contract when status updated to investor", async () => {
       await registry.transferFrom(
         founder.address,
         alice.address,
@@ -167,6 +167,17 @@ describe("Shareholder Registry", () => {
       await expect(registry.setStatus(INVESTOR_STATUS, alice.address))
         .to.emit(voting, "BeforeRemoveContributor")
         .withArgs(alice.address);
+    });
+    it.only("should not notify the Voting contract when status updated to founder", async () => {
+      await registry.transferFrom(
+        founder.address,
+        alice.address,
+        parseEther("1")
+      );
+      await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
+      await expect(
+        registry.setStatus(FOUNDER_STATUS, alice.address)
+      ).to.not.emit(voting, "BeforeRemoveContributor");
     });
     it("should cleanup the status when a shareholder transfers all their shares", async () => {
       await registry.transferFrom(


### PR DESCRIPTION
Fix bug on ShareoholderRegsitry demotion process.

ShareholderRegistry should call `beforeRemoveContributor` on Voting before someone that is at least contributor is demoted to someone that is at best investor.
The was making the demotion happen even when someone was promoted to Founder.
