### PR TITLE
Enhance TelediskoToken and ShareholderRegsitry

### DIFF
--- a/contracts/ShareholderRegistry/ShareholderRegistry.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistry.sol
@@ -63,4 +63,11 @@ contract ShareholderRegistry is
     {
         _burn(account, amount);
     }
+
+    function transferFromDAOBatch(address[] memory recipients)
+        public
+        onlyRole(Roles.OPERATOR_ROLE)
+    {
+        super._transferFromDAOBatch(recipients);
+    }
 }

--- a/contracts/ShareholderRegistry/ShareholderRegistry.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistry.sol
@@ -59,7 +59,7 @@ contract ShareholderRegistry is
 
     function burn(address account, uint256 amount)
         external
-        onlyRole(Roles.RESOLUTION_ROLE)
+        onlyRole(Roles.OPERATOR_ROLE)
     {
         _burn(account, amount);
     }

--- a/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
@@ -42,7 +42,7 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
     function _setStatus(bytes32 status, address account) internal virtual {
         require(
             status == 0 || isAtLeast(SHAREHOLDER_STATUS, account),
-            "Shareholder: address has no tokens"
+            "ShareholderRegistry: address has no tokens"
         );
         bytes32 previous = _statuses[account];
         _beforeSetStatus(account, previous, status);
@@ -123,12 +123,15 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
     ) internal virtual override {
         super._beforeTokenTransfer(from, to, amount);
 
-        require(amount == 1 ether * (amount / 1 ether), "No fractional tokens");
+        require(
+            amount == 1 ether * (amount / 1 ether),
+            "ShareholderRegistry: No fractional tokens"
+        );
         require(
             (balanceOf(to) == 0 && amount == 1 ether) ||
                 (to == address(this)) ||
                 (to == address(0)),
-            "Only the DAO can have more than 1 share"
+            "ShareholderRegistry: Only the DAO can have more than 1 share"
         );
     }
 

--- a/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "../Voting/IVoting.sol";
+import "hardhat/console.sol";
 
 contract ShareholderRegistryBase is ERC20Upgradeable {
     bytes32 public SHAREHOLDER_STATUS;
@@ -67,7 +68,7 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
         uint256 recipientLength = recipients.length;
 
         for (uint256 i = 0; i < recipientLength; ) {
-            transferFrom(address(this), recipients[i], 1);
+            _transfer(address(this), recipients[i], 1);
         }
     }
 
@@ -120,7 +121,9 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
         super._beforeTokenTransfer(from, to, amount);
 
         require(
-            balanceOf(to) > 0 && to != address(this),
+            (balanceOf(to) == 0 && amount == 1 ether) ||
+                (to == address(this)) ||
+                (to == address(0)),
             "Only the DAO can have more than 1 share"
         );
     }

--- a/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
@@ -120,6 +120,7 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
     ) internal virtual override {
         super._beforeTokenTransfer(from, to, amount);
 
+        require(amount == 1 ether * (amount / 1 ether), "No fractional tokens");
         require(
             (balanceOf(to) == 0 && amount == 1 ether) ||
                 (to == address(this)) ||

--- a/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import "../Voting/IVoting.sol";
-import "hardhat/console.sol";
 
 contract ShareholderRegistryBase is ERC20Upgradeable {
     bytes32 public SHAREHOLDER_STATUS;
@@ -68,7 +67,11 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
         uint256 recipientLength = recipients.length;
 
         for (uint256 i = 0; i < recipientLength; ) {
-            _transfer(address(this), recipients[i], 1);
+            _transfer(address(this), recipients[i], 1 ether);
+
+            unchecked {
+                i++;
+            }
         }
     }
 

--- a/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
+++ b/contracts/ShareholderRegistry/ShareholderRegistryBase.sol
@@ -63,6 +63,14 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
         return _isAtLeast(balanceOf(account), _statuses[account], status);
     }
 
+    function _transferFromDAOBatch(address[] memory recipients) internal {
+        uint256 recipientLength = recipients.length;
+
+        for (uint256 i = 0; i < recipientLength; ) {
+            transferFrom(address(this), recipients[i], 1);
+        }
+    }
+
     function _isAtLeast(
         uint256 balance,
         bytes32 accountStatus,
@@ -102,6 +110,19 @@ contract ShareholderRegistryBase is ERC20Upgradeable {
         ) {
             _voting.afterAddContributor(account);
         }
+    }
+
+    function _beforeTokenTransfer(
+        address from,
+        address to,
+        uint256 amount
+    ) internal virtual override {
+        super._beforeTokenTransfer(from, to, amount);
+
+        require(
+            balanceOf(to) > 0 && to != address(this),
+            "Only the DAO can have more than 1 share"
+        );
     }
 
     function _afterTokenTransfer(

--- a/contracts/TelediskoToken/TelediskoToken.sol
+++ b/contracts/TelediskoToken/TelediskoToken.sol
@@ -76,4 +76,11 @@ contract TelediskoToken is
     {
         _setVesting(to, amount);
     }
+
+    function burn(address account, uint256 amount)
+        public
+        onlyRole(Roles.OPERATOR_ROLE)
+    {
+        super._burn(account, amount);
+    }
 }

--- a/contracts/TelediskoToken/TelediskoTokenBase.sol
+++ b/contracts/TelediskoToken/TelediskoTokenBase.sol
@@ -307,8 +307,8 @@ contract TelediskoTokenBase is ERC20Upgradeable {
         ) {
             (, uint256 unlocked) = _calculateOffersOf(account);
             return unlocked;
-        } else {
-            return balanceOf(account);
         }
+
+        return balanceOf(account);
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -40,7 +40,17 @@ const GAS_PRICE = process.env.GAS_PRICE
 const config: HardhatUserConfig = {
   defaultNetwork: "hardhat",
   solidity: {
-    compilers: [{ version: "0.8.11", settings: {} }],
+    compilers: [
+      {
+        version: "0.8.11",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   networks: {
     hardhat: {},

--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -12,6 +12,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { setEVMTimestamp, getEVMTimestamp, mineEVMBlock } from "./utils/evm";
 import { roles } from "./utils/roles";
 import { deployDAO } from "./utils/deploy";
+import { parseEther } from "ethers/lib/utils";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);
@@ -55,7 +56,7 @@ describe("Integration", () => {
     }
 
     async function _prepareForVoting(user: SignerWithAddress, tokens: number) {
-      await shareholderRegistry.mint(user.address, 1);
+      await shareholderRegistry.mint(user.address, parseEther("1"));
       await shareholderRegistry.setStatus(contributorStatus, user.address);
       await _mintTokens(user, tokens);
     }
@@ -279,7 +280,7 @@ describe("Integration", () => {
       // votes given from non DAO members
       await expect(_vote(user2, true, resolutionId)).reverted;
       // votes given from less than Contributors
-      await shareholderRegistry.mint(user2.address, 1);
+      await shareholderRegistry.mint(user2.address, parseEther("1"));
       await shareholderRegistry.setStatus(investorStatus, user2.address);
 
       const resolutionId2 = await _prepareResolution();
@@ -292,7 +293,7 @@ describe("Integration", () => {
         await roles.RESOLUTION_ROLE(),
         deployer.address
       );
-      await shareholderRegistry.burn(user3.address, 1);
+      await shareholderRegistry.burn(user3.address, parseEther("1"));
       const resolutionId3 = await _prepareResolution();
       await _makeVotable(resolutionId3);
       await expect(_vote(user3, true, resolutionId3)).reverted;

--- a/test/ResolutionManager.ts
+++ b/test/ResolutionManager.ts
@@ -23,8 +23,6 @@ const { expect } = chai;
 
 const DAY = 60 * 60 * 24;
 
-const AddressZero = ethers.constants.AddressZero;
-
 describe("Resolution", () => {
   let managingBoardStatus: string;
   let contributorStatus: string;

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -448,7 +448,27 @@ describe("Shareholder Registry", () => {
     });
   });
 
-  describe("tokenomics", async () => {
+  describe("transferFromDAOBatch", async () => {
+    it("allow transfering DAO shares to multiple addresses", async () => {
+      await registry.mint(registry.address, parseEther("20"));
+
+      await expect(
+        registry.transferFromDAOBatch([
+          alice.address,
+          bob.address,
+          managingBoard.address,
+        ])
+      );
+
+      expect(await registry.balanceOf(alice.address)).equal(parseEther("1"));
+      expect(await registry.balanceOf(bob.address)).equal(parseEther("1"));
+      expect(await registry.balanceOf(managingBoard.address)).equal(
+        parseEther("1")
+      );
+    });
+  });
+
+  describe("transfer", async () => {
     it("should prevent non-DAO addresses from receiving more than 1 share", async () => {
       await expect(registry.mint(alice.address, parseEther("2"))).revertedWith(
         "Only the DAO can have more than 1 share"
@@ -463,23 +483,25 @@ describe("Shareholder Registry", () => {
     });
 
     it("should allow the DAO to receive more than 1 share", async () => {
-      await expect(registry.mint(registry.address, parseEther("10")))
-        .to.emit(registry, "Transfer")
-        .withArgs(AddressZero, registry.address, parseEther("10"));
+      await registry.mint(registry.address, parseEther("10"));
+
+      expect(await registry.balanceOf(registry.address)).equal(
+        parseEther("10")
+      );
     });
 
     it("should allow the DAO to receive 1 share after they already got one", async () => {
       await registry.mint(registry.address, parseEther("1"));
-      await expect(registry.mint(registry.address, parseEther("1")))
-        .to.emit(registry, "Transfer")
-        .withArgs(AddressZero, registry.address, parseEther("1"));
+      await registry.mint(registry.address, parseEther("1"));
+
+      expect(await registry.balanceOf(registry.address)).equal(parseEther("2"));
     });
 
     it("should allow burning as many tokens as desired", async () => {
       await registry.mint(registry.address, parseEther("10"));
-      await expect(registry.burn(registry.address, parseEther("5")))
-        .to.emit(registry, "Transfer")
-        .withArgs(registry.address, AddressZero, parseEther("5"));
+      await registry.burn(registry.address, parseEther("4"));
+
+      expect(await registry.balanceOf(registry.address)).equal(parseEther("6"));
     });
 
     it("should not allow to transfer factional tokens", async () => {

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -75,7 +75,7 @@ describe("Shareholder Registry", () => {
     it("should fail if address is not a shareholder set the given type for an address", async () => {
       await expect(
         registry.setStatus(CONTRIBUTOR_STATUS, alice.address)
-      ).revertedWith("Shareholder: address has no tokens");
+      ).revertedWith("ShareholderRegistry: address has no tokens");
     });
 
     it("should be callable only by a operator", async () => {
@@ -471,14 +471,14 @@ describe("Shareholder Registry", () => {
   describe("transfer", async () => {
     it("should prevent non-DAO addresses from receiving more than 1 share", async () => {
       await expect(registry.mint(alice.address, parseEther("2"))).revertedWith(
-        "Only the DAO can have more than 1 share"
+        "ShareholderRegistry: Only the DAO can have more than 1 share"
       );
     });
 
     it("should prevent non-DAO addresses from receiving 1 share after they already got one", async () => {
       await registry.mint(alice.address, parseEther("1"));
       await expect(registry.mint(alice.address, parseEther("1"))).revertedWith(
-        "Only the DAO can have more than 1 share"
+        "ShareholderRegistry: Only the DAO can have more than 1 share"
       );
     });
 

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -462,13 +462,13 @@ describe("Shareholder Registry", () => {
       );
     });
 
-    it("should allow the DAO to receiving more than 1 share", async () => {
+    it("should allow the DAO to receive more than 1 share", async () => {
       await expect(registry.mint(registry.address, parseEther("10")))
         .to.emit(registry, "Transfer")
         .withArgs(AddressZero, registry.address, parseEther("10"));
     });
 
-    it("should allow the DAO to receiving 1 share after they already got one", async () => {
+    it("should allow the DAO to receive 1 share after they already got one", async () => {
       await registry.mint(registry.address, parseEther("1"));
       await expect(registry.mint(registry.address, parseEther("1")))
         .to.emit(registry, "Transfer")

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -306,7 +306,7 @@ describe("Shareholder Registry", () => {
           registry.connect(bob).burn(registry.address, 4)
         ).revertedWith(
           `AccessControl: account ${bob.address.toLowerCase()} ` +
-            `is missing role ${RESOLUTION_ROLE}`
+            `is missing role ${OPERATOR_ROLE}`
         );
       });
 

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -19,6 +19,8 @@ const { expect } = chai;
 const Bytes32Zero =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
+const AddressZero = ethers.constants.AddressZero;
+
 describe("Shareholder Registry", () => {
   let RESOLUTION_ROLE: string,
     OPERATOR_ROLE: string,
@@ -32,11 +34,10 @@ describe("Shareholder Registry", () => {
   let operator: SignerWithAddress,
     managingBoard: SignerWithAddress,
     alice: SignerWithAddress,
-    bob: SignerWithAddress,
-    carol: SignerWithAddress;
+    bob: SignerWithAddress;
 
   beforeEach(async () => {
-    [operator, managingBoard, alice, bob, carol] = await ethers.getSigners();
+    [operator, managingBoard, alice, bob] = await ethers.getSigners();
     const ShareholderRegistryFactory = (await ethers.getContractFactory(
       "ShareholderRegistry",
       operator
@@ -68,10 +69,6 @@ describe("Shareholder Registry", () => {
     await registry.grantRole(RESOLUTION_ROLE, operator.address);
     await registry.grantRole(OPERATOR_ROLE, operator.address);
     await registry.setVoting(voting.address);
-    await registry.mint(managingBoard.address, shareCapital);
-    await registry
-      .connect(managingBoard)
-      .approve(operator.address, shareCapital);
   });
 
   describe("Status management", () => {
@@ -111,11 +108,7 @@ describe("Shareholder Registry", () => {
       expect(await registry.isAtLeast(INVESTOR_STATUS, alice.address)).equal(
         false
       );
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       expect(await registry.isAtLeast(SHAREHOLDER_STATUS, alice.address)).equal(
         true
       );
@@ -134,11 +127,7 @@ describe("Shareholder Registry", () => {
       expect(await registry.isAtLeast(CONTRIBUTOR_STATUS, alice.address)).equal(
         false
       );
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
       expect(await registry.isAtLeast(SHAREHOLDER_STATUS, alice.address)).equal(
         true
@@ -152,26 +141,18 @@ describe("Shareholder Registry", () => {
     });
 
     it("should notify the Voting contract when a shareholder transfers all their shares", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
       expect(await registry.getStatus(alice.address)).equal(CONTRIBUTOR_STATUS);
       await expect(
-        registry.connect(alice).transfer(managingBoard.address, parseEther("1"))
+        registry.connect(alice).transfer(registry.address, parseEther("1"))
       )
         .to.emit(voting, "BeforeRemoveContributor")
         .withArgs(alice.address);
     });
 
     it("should notify the Voting contract when status updated to investor", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
       await expect(registry.setStatus(INVESTOR_STATUS, alice.address))
         .to.emit(voting, "BeforeRemoveContributor")
@@ -179,11 +160,7 @@ describe("Shareholder Registry", () => {
     });
 
     it("should not notify the Voting contract when status updated to managingBoard", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
       await expect(
         registry.setStatus(MANAGING_BOARD_STATUS, alice.address)
@@ -191,22 +168,14 @@ describe("Shareholder Registry", () => {
     });
 
     it("should call afterAddContributor when status updated for the first time to contributor", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await expect(
         registry.setStatus(CONTRIBUTOR_STATUS, alice.address)
       ).to.emit(voting, "AfterAddContributor");
     });
 
     it("should not call afterAddContributor when status is already at least contributor", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
       await expect(
         registry.setStatus(MANAGING_BOARD_STATUS, alice.address)
@@ -214,11 +183,7 @@ describe("Shareholder Registry", () => {
     });
 
     it("should not notify the Voting contract when adding an investor", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
 
       await expect(
         registry.setStatus(INVESTOR_STATUS, alice.address)
@@ -226,16 +191,10 @@ describe("Shareholder Registry", () => {
     });
 
     it("should cleanup the status when a shareholder transfers all their shares", async () => {
-      await registry.transferFrom(
-        managingBoard.address,
-        alice.address,
-        parseEther("1")
-      );
+      await registry.mint(alice.address, parseEther("1"));
       await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
       expect(await registry.getStatus(alice.address)).equal(CONTRIBUTOR_STATUS);
-      await registry
-        .connect(alice)
-        .transfer(managingBoard.address, parseEther("1"));
+      await registry.connect(alice).transfer(registry.address, parseEther("1"));
       expect(await registry.getStatus(alice.address)).equal(Bytes32Zero);
     });
   });
@@ -271,11 +230,7 @@ describe("Shareholder Registry", () => {
         expect(await registry.balanceOf(alice.address)).equal(0);
         await registry.snapshot();
         const snapshotIdBefore = await registry.getCurrentSnapshotId();
-        await registry.transferFrom(
-          managingBoard.address,
-          alice.address,
-          parseEther("1")
-        );
+        await registry.mint(alice.address, parseEther("1"));
         expect(await registry.balanceOf(alice.address)).equal(parseEther("1"));
         expect(
           await registry.balanceOfAt(alice.address, snapshotIdBefore)
@@ -307,13 +262,14 @@ describe("Shareholder Registry", () => {
       });
 
       it("returns the correct value per snapshot", async () => {
+        await registry.mint(registry.address, shareCapital);
         expect(await registry.totalSupply()).equal(shareCapital);
         await registry.snapshot();
         const snapshotIdBefore = await registry.getCurrentSnapshotId();
         expect(await registry.totalSupplyAt(snapshotIdBefore)).equal(
           shareCapital
         );
-        await registry.mint(managingBoard.address, parseEther("5"));
+        await registry.mint(registry.address, parseEther("5"));
         expect(await registry.totalSupply()).equal(
           shareCapital.add(parseEther("5"))
         );
@@ -330,22 +286,24 @@ describe("Shareholder Registry", () => {
 
     describe("burn", () => {
       it("allows a resolution to burn shares of an account", async () => {
+        await registry.mint(registry.address, parseEther("5"));
         await expect(() =>
-          registry.burn(managingBoard.address, 4)
-        ).changeTokenBalance(registry, managingBoard, -4);
+          registry.burn(registry.address, parseEther("4"))
+        ).changeTokenBalance(registry, registry, parseEther("-4"));
       });
 
       it("updates total supply", async () => {
+        await registry.mint(registry.address, parseEther("5"));
         const totalSupplyBefore = await registry.totalSupply();
-        await registry.burn(managingBoard.address, 1);
+        await registry.burn(registry.address, parseEther("1"));
 
         const totalSupplyAfter = await registry.totalSupply();
-        expect(totalSupplyAfter).equal(totalSupplyBefore.sub(1));
+        expect(totalSupplyAfter).equal(totalSupplyBefore.sub(parseEther("1")));
       });
 
       it("does not allows anyone not RESOLUTION_ROLE to not be able to burn shares", async () => {
         await expect(
-          registry.connect(bob).burn(managingBoard.address, 4)
+          registry.connect(bob).burn(registry.address, 4)
         ).revertedWith(
           `AccessControl: account ${bob.address.toLowerCase()} ` +
             `is missing role ${RESOLUTION_ROLE}`
@@ -353,20 +311,17 @@ describe("Shareholder Registry", () => {
       });
 
       it("should cleanup the account status when its share is burnt", async () => {
-        await registry.transferFrom(
-          managingBoard.address,
-          alice.address,
-          parseEther("1")
-        );
+        await registry.mint(alice.address, parseEther("1"));
         await registry.burn(alice.address, parseEther("1"));
 
         expect(await registry.getStatus(alice.address)).equal(Bytes32Zero);
       });
 
       it("updates the snapshots", async () => {
+        await registry.mint(registry.address, parseEther("5"));
         await registry.snapshot();
         const snapshotIdBefore = await registry.getCurrentSnapshotId();
-        await registry.burn(managingBoard.address, 1);
+        await registry.burn(registry.address, parseEther("1"));
 
         await registry.snapshot();
         const snapshotIdAfter = await registry.getCurrentSnapshotId();
@@ -375,7 +330,7 @@ describe("Shareholder Registry", () => {
           snapshotIdBefore
         );
         const totalSupplyAfter = await registry.totalSupplyAt(snapshotIdAfter);
-        expect(totalSupplyAfter).equal(totalSupplyBefore.sub(1));
+        expect(totalSupplyAfter).equal(totalSupplyBefore.sub(parseEther("1")));
       });
     });
 
@@ -397,11 +352,7 @@ describe("Shareholder Registry", () => {
         await registry.snapshot();
         const snapshotIdBefore = await registry.getCurrentSnapshotId();
 
-        await registry.transferFrom(
-          managingBoard.address,
-          alice.address,
-          parseEther("1")
-        );
+        await registry.mint(alice.address, parseEther("1"));
         await registry.setStatus(CONTRIBUTOR_STATUS, alice.address);
 
         await registry.snapshot();
@@ -439,11 +390,7 @@ describe("Shareholder Registry", () => {
         await registry.snapshot();
         const snapshotId0 = await registry.getCurrentSnapshotId();
 
-        await registry.transferFrom(
-          managingBoard.address,
-          alice.address,
-          parseEther("1")
-        );
+        await registry.mint(alice.address, parseEther("1"));
         expect(
           await registry.isAtLeastAt(
             SHAREHOLDER_STATUS,
@@ -498,6 +445,34 @@ describe("Shareholder Registry", () => {
           )
         ).equal(true);
       });
+    });
+  });
+
+  describe("tokenomics", async () => {
+    it("should prevent non-DAO addresses from receiving more than 1 share", async () => {
+      await expect(registry.mint(alice.address, parseEther("2"))).revertedWith(
+        "Only the DAO can have more than 1 share"
+      );
+    });
+
+    it("should prevent non-DAO addresses from receiving 1 share after they already got one", async () => {
+      await registry.mint(alice.address, parseEther("1"));
+      await expect(registry.mint(alice.address, parseEther("1"))).revertedWith(
+        "Only the DAO can have more than 1 share"
+      );
+    });
+
+    it("should allow the DAO to receiving more than 1 share", async () => {
+      await expect(registry.mint(registry.address, parseEther("10")))
+        .to.emit(registry, "Transfer")
+        .withArgs(AddressZero, registry.address, parseEther("10"));
+    });
+
+    it("should allow the DAO to receiving 1 share after they already got one", async () => {
+      await registry.mint(registry.address, parseEther("1"));
+      await expect(registry.mint(registry.address, parseEther("1")))
+        .to.emit(registry, "Transfer")
+        .withArgs(AddressZero, registry.address, parseEther("1"));
     });
   });
 });

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -474,5 +474,22 @@ describe("Shareholder Registry", () => {
         .to.emit(registry, "Transfer")
         .withArgs(AddressZero, registry.address, parseEther("1"));
     });
+
+    it("should allow burning as many tokens as desired", async () => {
+      await registry.mint(registry.address, parseEther("10"));
+      await expect(registry.burn(registry.address, parseEther("5")))
+        .to.emit(registry, "Transfer")
+        .withArgs(registry.address, AddressZero, parseEther("5"));
+    });
+
+    it("should not allow to transfer factional tokens", async () => {
+      await expect(
+        registry.mint(registry.address, parseEther("0.1"))
+      ).revertedWith("No fractional tokens");
+
+      await expect(
+        registry.mint(registry.address, parseEther("2.5"))
+      ).revertedWith("No fractional tokens");
+    });
   });
 });

--- a/test/TelediskoTokenSnapshot.ts
+++ b/test/TelediskoTokenSnapshot.ts
@@ -1,0 +1,281 @@
+import { ethers, upgrades } from "hardhat";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
+import { solidity } from "ethereum-waffle";
+import {
+  TelediskoToken,
+  TelediskoToken__factory,
+  ShareholderRegistryMock,
+  ShareholderRegistryMock__factory,
+  VotingMock,
+  VotingMock__factory,
+} from "../typechain";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { setEVMTimestamp, getEVMTimestamp, mineEVMBlock } from "./utils/evm";
+import { roles } from "./utils/roles";
+
+chai.use(solidity);
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+const AddressZero = ethers.constants.AddressZero;
+
+const DAY = 60 * 60 * 24;
+const WEEK = DAY * 7;
+
+describe("TelediskoTokenSnapshot", () => {
+  let RESOLUTION_ROLE: string, OPERATOR_ROLE: string;
+  let telediskoToken: TelediskoToken;
+  let voting: VotingMock;
+  let shareholderRegistry: ShareholderRegistryMock;
+  let deployer: SignerWithAddress,
+    account: SignerWithAddress,
+    contributor: SignerWithAddress,
+    contributor2: SignerWithAddress,
+    nonContributor: SignerWithAddress;
+
+  beforeEach(async () => {
+    [deployer, account, contributor, contributor2, nonContributor] =
+      await ethers.getSigners();
+
+    const TelediskoTokenFactory = (await ethers.getContractFactory(
+      "TelediskoToken",
+      deployer
+    )) as TelediskoToken__factory;
+
+    const VotingMockFactory = (await ethers.getContractFactory(
+      "VotingMock",
+      deployer
+    )) as VotingMock__factory;
+
+    const ShareholderRegistryMockFactory = (await ethers.getContractFactory(
+      "ShareholderRegistryMock",
+      deployer
+    )) as ShareholderRegistryMock__factory;
+
+    telediskoToken = (await upgrades.deployProxy(
+      TelediskoTokenFactory,
+      ["Test", "TEST"],
+      { initializer: "initialize" }
+    )) as TelediskoToken;
+    await telediskoToken.deployed();
+
+    voting = (await upgrades.deployProxy(VotingMockFactory)) as VotingMock;
+    await voting.deployed();
+
+    RESOLUTION_ROLE = await roles.RESOLUTION_ROLE();
+    await telediskoToken.grantRole(RESOLUTION_ROLE, deployer.address);
+
+    OPERATOR_ROLE = await roles.OPERATOR_ROLE();
+    await telediskoToken.grantRole(OPERATOR_ROLE, deployer.address);
+
+    shareholderRegistry = (await upgrades.deployProxy(
+      ShareholderRegistryMockFactory,
+      {
+        initializer: "initialize",
+      }
+    )) as ShareholderRegistryMock;
+    await shareholderRegistry.deployed();
+
+    await telediskoToken.setVoting(voting.address);
+    await telediskoToken.setShareholderRegistry(shareholderRegistry.address);
+
+    const contributorStatus = await shareholderRegistry.CONTRIBUTOR_STATUS();
+    const shareholderStatus = await shareholderRegistry.SHAREHOLDER_STATUS();
+    const investorStatus = await shareholderRegistry.INVESTOR_STATUS();
+
+    await setContributor(contributor, true);
+    await setContributor(contributor2, true);
+
+    async function setContributor(user: SignerWithAddress, flag: boolean) {
+      await shareholderRegistry.mock_isAtLeast(
+        contributorStatus,
+        user.address,
+        flag
+      );
+      await shareholderRegistry.mock_isAtLeast(
+        shareholderStatus,
+        user.address,
+        flag
+      );
+      await shareholderRegistry.mock_isAtLeast(
+        investorStatus,
+        user.address,
+        flag
+      );
+    }
+  });
+
+  describe("snapshot logic", async () => {
+    it("should increase snapshot id", async () => {
+      await telediskoToken.snapshot();
+      let snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+      await telediskoToken.snapshot();
+      let snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+      expect(snapshotIdBefore.toNumber()).lessThan(snapshotIdAfter.toNumber());
+    });
+
+    describe("balanceOfAt", async () => {
+      it("should return the balance at the time of the snapshot - mint", async () => {
+        await telediskoToken.mint(contributor.address, 10);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken.mint(contributor.address, 3);
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.balanceOfAt(
+          contributor.address,
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.balanceOfAt(
+          contributor.address,
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(10);
+        expect(balanceAfter).equal(13);
+      });
+
+      it("should return the balance at the time of the snapshot - transfer send", async () => {
+        await telediskoToken.mint(nonContributor.address, 10);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken
+          .connect(nonContributor)
+          .transfer(contributor.address, 3);
+
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.balanceOfAt(
+          nonContributor.address,
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.balanceOfAt(
+          nonContributor.address,
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(10);
+        expect(balanceAfter).equal(7);
+      });
+
+      it("should return the balance at the time of the snapshot - transfer receive", async () => {
+        await telediskoToken.mint(nonContributor.address, 10);
+        await telediskoToken.mint(contributor.address, 3);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken
+          .connect(nonContributor)
+          .transfer(contributor.address, 4);
+
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.balanceOfAt(
+          contributor.address,
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.balanceOfAt(
+          contributor.address,
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(3);
+        expect(balanceAfter).equal(7);
+      });
+
+      it("should return the balance at the time of the snapshot - burn", async () => {
+        await telediskoToken.mint(nonContributor.address, 10);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken.burn(nonContributor.address, 4);
+
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.balanceOfAt(
+          nonContributor.address,
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.balanceOfAt(
+          nonContributor.address,
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(10);
+        expect(balanceAfter).equal(6);
+      });
+    });
+
+    describe("totalSupplyAt", async () => {
+      it("should return the totalSupply at the time of the snapshot - mint", async () => {
+        await telediskoToken.mint(contributor.address, 10);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken.mint(nonContributor.address, 3);
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.totalSupplyAt(
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.totalSupplyAt(
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(10);
+        expect(balanceAfter).equal(13);
+      });
+
+      it("should return the totalSupply at the time of the snapshot - transfer", async () => {
+        await telediskoToken.mint(nonContributor.address, 10);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken
+          .connect(nonContributor)
+          .transfer(contributor.address, 3);
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.totalSupplyAt(
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.totalSupplyAt(
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(10);
+        expect(balanceAfter).equal(10);
+      });
+
+      it("should return the totalSupply at the time of the snapshot - burn", async () => {
+        await telediskoToken.mint(nonContributor.address, 10);
+        await telediskoToken.snapshot();
+        const snapshotIdBefore = await telediskoToken.getCurrentSnapshotId();
+
+        await telediskoToken.burn(nonContributor.address, 7);
+        await telediskoToken.snapshot();
+        const snapshotIdAfter = await telediskoToken.getCurrentSnapshotId();
+
+        const balanceBefore = await telediskoToken.totalSupplyAt(
+          snapshotIdBefore
+        );
+        const balanceAfter = await telediskoToken.totalSupplyAt(
+          snapshotIdAfter
+        );
+
+        expect(balanceBefore).equal(10);
+        expect(balanceAfter).equal(3);
+      });
+    });
+  });
+});

--- a/test/Upgrade.ts
+++ b/test/Upgrade.ts
@@ -14,6 +14,7 @@ import {
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { setEVMTimestamp, getEVMTimestamp, mineEVMBlock } from "./utils/evm";
 import { deployDAO } from "./utils/deploy";
+import { parseEther } from "ethers/lib/utils";
 
 chai.use(solidity);
 chai.use(chaiAsPromised);
@@ -60,7 +61,7 @@ describe("Upgrade", () => {
     }
 
     async function _prepareForVoting(user: SignerWithAddress, tokens: number) {
-      await shareholderRegistry.mint(user.address, 1);
+      await shareholderRegistry.mint(user.address, parseEther("1"));
       await shareholderRegistry.setStatus(contributorStatus, user.address);
       await _mintTokens(user, tokens);
     }
@@ -135,11 +136,11 @@ describe("Upgrade", () => {
 
     it("should change contract logic", async () => {
       // Prevents also shareholder from transfering their tokens on TelediskoToken
-      await shareholderRegistry.mint(user1.address, 1);
+      await shareholderRegistry.mint(user1.address, parseEther("1"));
       await shareholderRegistry.setStatus(contributorStatus, user1.address);
       await _mintTokens(user1, 42);
 
-      await shareholderRegistry.mint(user2.address, 1);
+      await shareholderRegistry.mint(user2.address, parseEther("1"));
       await shareholderRegistry.setStatus(shareholderStatus, user2.address);
       await _mintTokens(user2, 42);
 

--- a/test/VotingSnapshot.ts
+++ b/test/VotingSnapshot.ts
@@ -9,7 +9,6 @@ import {
   ERC20Mock__factory,
   ShareholderRegistryMock,
   ShareholderRegistryMock__factory,
-  VotingSnapshot,
 } from "../typechain";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { roles } from "./utils/roles";

--- a/test/utils/deploy.ts
+++ b/test/utils/deploy.ts
@@ -1,4 +1,5 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { parseEther } from "ethers/lib/utils";
 import { ethers, upgrades } from "hardhat";
 import { ShareholderRegistry, TelediskoToken, Voting } from "../../typechain";
 import { ResolutionManager } from "../../typechain";
@@ -91,7 +92,7 @@ export async function deployDAO(
 
   var managingBoardStatus = await shareholderRegistry.MANAGING_BOARD_STATUS();
 
-  await shareholderRegistry.mint(managingBoard.address, 1);
+  await shareholderRegistry.mint(managingBoard.address, parseEther("1"));
   await shareholderRegistry.setStatus(
     managingBoardStatus,
     managingBoard.address


### PR DESCRIPTION
- Prevent transferring of more than 1 share to any address that is not the DAO (ShareholderRegistry)
- Prevent transferring fractional shares (it must be a multiple of 1 ether)
- Add batch transfer function for ShareholderRegistry, to allow the DAO to distribute shares to multiple users in one shot 
- Enable `burn` in Teledisko Token (only by operators)
- Extend test coverage (including snapshot functionalities on TelediskoToken)  

Close #64 
Close #63 