### PR TITLE
Speed of light tests

### DIFF
--- a/test/Integration.ts
+++ b/test/Integration.ts
@@ -1,4 +1,4 @@
-import { ethers } from "hardhat";
+import { ethers, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -24,6 +24,8 @@ const { expect } = chai;
 const DAY = 60 * 60 * 24;
 
 describe("Integration", async () => {
+  let snapshotId: string;
+
   let voting: Voting;
   let token: TelediskoToken;
   let resolution: ResolutionManager;
@@ -37,7 +39,7 @@ describe("Integration", async () => {
     user2: SignerWithAddress,
     user3: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [deployer, managingBoard, user1, user2, user3] = await ethers.getSigners();
     ({ voting, token, registry, resolution, market } = await deployDAO(
       deployer,
@@ -46,6 +48,14 @@ describe("Integration", async () => {
 
     contributorStatus = await registry.CONTRIBUTOR_STATUS();
     investorStatus = await registry.INVESTOR_STATUS();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("integration", async () => {

--- a/test/PriceOracle.ts
+++ b/test/PriceOracle.ts
@@ -1,4 +1,4 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -9,12 +9,13 @@ import { BigNumber } from "ethers";
 chai.use(solidity);
 chai.use(chaiAsPromised);
 const { expect } = chai;
+let snapshotId: string;
 
-describe("PriceOracle", () => {
+describe("PriceOracle", async () => {
   let priceOracle: PriceOracle;
   let deployer: SignerWithAddress, account: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [deployer, account] = await ethers.getSigners();
 
     const PriceOracleFactory = (await ethers.getContractFactory(
@@ -24,6 +25,14 @@ describe("PriceOracle", () => {
 
     priceOracle = await PriceOracleFactory.deploy();
     await priceOracle.deployed();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("relay", async () => {

--- a/test/ShareholderRegistrySnapshot.ts
+++ b/test/ShareholderRegistrySnapshot.ts
@@ -1,4 +1,4 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers, upgrades, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -19,9 +19,9 @@ const { expect } = chai;
 const Bytes32Zero =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 
-const AddressZero = ethers.constants.AddressZero;
-
 describe("Shareholder Registry", () => {
+  let snapshotId: string;
+
   let RESOLUTION_ROLE: string,
     OPERATOR_ROLE: string,
     SHAREHOLDER_STATUS: string,
@@ -36,7 +36,7 @@ describe("Shareholder Registry", () => {
     alice: SignerWithAddress,
     bob: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [operator, managingBoard, alice, bob] = await ethers.getSigners();
     const ShareholderRegistryFactory = (await ethers.getContractFactory(
       "ShareholderRegistry",
@@ -69,6 +69,14 @@ describe("Shareholder Registry", () => {
     await registry.grantRole(RESOLUTION_ROLE, operator.address);
     await registry.grantRole(OPERATOR_ROLE, operator.address);
     await registry.setVoting(voting.address);
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("Status management", () => {

--- a/test/TelediskoToken.ts
+++ b/test/TelediskoToken.ts
@@ -1,4 +1,4 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers, upgrades, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -19,10 +19,9 @@ const { expect } = chai;
 
 const AddressZero = ethers.constants.AddressZero;
 
-const DAY = 60 * 60 * 24;
-const WEEK = DAY * 7;
-
 describe("TelediskoToken", () => {
+  let snapshotId: string;
+
   let RESOLUTION_ROLE: string, OPERATOR_ROLE: string, ESCROW_ROLE: string;
   let telediskoToken: TelediskoToken;
   let voting: VotingMock;
@@ -33,7 +32,7 @@ describe("TelediskoToken", () => {
     contributor2: SignerWithAddress,
     nonContributor: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [deployer, account, contributor, contributor2, nonContributor] =
       await ethers.getSigners();
 
@@ -106,6 +105,14 @@ describe("TelediskoToken", () => {
         flag
       );
     }
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("token transfer logic", async () => {

--- a/test/TelediskoTokenSnapshot.ts
+++ b/test/TelediskoTokenSnapshot.ts
@@ -1,4 +1,4 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers, upgrades, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -17,12 +17,9 @@ chai.use(solidity);
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-const AddressZero = ethers.constants.AddressZero;
-
-const DAY = 60 * 60 * 24;
-const WEEK = DAY * 7;
-
 describe("TelediskoTokenSnapshot", () => {
+  let snapshotId: string;
+
   let RESOLUTION_ROLE: string, OPERATOR_ROLE: string;
   let telediskoToken: TelediskoToken;
   let voting: VotingMock;
@@ -33,7 +30,7 @@ describe("TelediskoTokenSnapshot", () => {
     contributor2: SignerWithAddress,
     nonContributor: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [deployer, account, contributor, contributor2, nonContributor] =
       await ethers.getSigners();
 
@@ -106,6 +103,14 @@ describe("TelediskoTokenSnapshot", () => {
         flag
       );
     }
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("snapshot logic", async () => {

--- a/test/Upgrade.ts
+++ b/test/Upgrade.ts
@@ -1,10 +1,9 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers, upgrades, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
 import {
   ShareholderRegistry,
-  Voting,
   TelediskoToken,
   ResolutionManager,
   ResolutionManagerV2Mock__factory,
@@ -23,6 +22,8 @@ const { expect } = chai;
 const DAY = 60 * 60 * 24;
 
 describe("Upgrade", () => {
+  let snapshotId: string;
+
   let token: TelediskoToken;
   let registry: ShareholderRegistry;
   let resolution: ResolutionManager;
@@ -36,7 +37,7 @@ describe("Upgrade", () => {
   let user2: SignerWithAddress;
   let user3: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [deployer, managingBoard, user1, user2, user3] = await ethers.getSigners();
     ({ token, registry, resolution } = await deployDAO(
       deployer,
@@ -47,6 +48,14 @@ describe("Upgrade", () => {
     contributorStatus = await registry.CONTRIBUTOR_STATUS();
     shareholderStatus = await registry.SHAREHOLDER_STATUS();
     investorStatus = await registry.INVESTOR_STATUS();
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   describe("upgrades", async () => {

--- a/test/Voting.ts
+++ b/test/Voting.ts
@@ -1,5 +1,4 @@
-import { ethers } from "hardhat";
-import { upgrades } from "hardhat";
+import { ethers, upgrades, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -21,6 +20,8 @@ const { expect } = chai;
 const AddressZero = ethers.constants.AddressZero;
 
 describe("Voting", () => {
+  let snapshotId: string;
+
   let contributorStatus: string;
   let shareholderStatus: string;
   let investorStatus: string;
@@ -40,7 +41,7 @@ describe("Voting", () => {
     noDelegate: SignerWithAddress,
     nonContributor: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [
       deployer,
       delegator1,
@@ -113,6 +114,14 @@ describe("Voting", () => {
         await voting.connect(voter).delegate(voter.address);
       })
     );
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   async function setContributor(user: SignerWithAddress, flag: boolean) {

--- a/test/VotingSnapshot.ts
+++ b/test/VotingSnapshot.ts
@@ -1,4 +1,4 @@
-import { ethers, upgrades } from "hardhat";
+import { ethers, upgrades, network } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { solidity } from "ethereum-waffle";
@@ -20,6 +20,8 @@ const { expect } = chai;
 const AddressZero = ethers.constants.AddressZero;
 
 describe("VotingSnapshot", () => {
+  let snapshotId: string;
+
   let contributorStatus: string;
   let shareholderStatus: string;
   let investorStatus: string;
@@ -39,7 +41,7 @@ describe("VotingSnapshot", () => {
     noDelegate: SignerWithAddress,
     nonContributor: SignerWithAddress;
 
-  beforeEach(async () => {
+  before(async () => {
     [
       deployer,
       delegator1,
@@ -115,6 +117,14 @@ describe("VotingSnapshot", () => {
         await votingSnapshot.connect(voter).delegate(voter.address);
       })
     );
+  });
+
+  beforeEach(async () => {
+    snapshotId = await network.provider.send("evm_snapshot");
+  });
+
+  afterEach(async () => {
+    await network.provider.send("evm_revert", [snapshotId]);
   });
 
   async function setContributor(user: SignerWithAddress, flag: boolean) {


### PR DESCRIPTION
Rather than redeploying the contracts before each test, we now leverage the evm snapshot functionality: at the beginning of every test we take a snapshot and at the end of the test we revert the evm to that snapshot.

From 1 minute down to 14 seconds on my machine. Comparable improvement on our CI

before
![Screenshot 2023-01-30 at 16 05 58](https://user-images.githubusercontent.com/936916/215514367-3ea2999f-3397-4e1c-a68d-91e48d3602f4.png)

after
![Screenshot 2023-01-30 at 16 05 36](https://user-images.githubusercontent.com/936916/215514362-a7bdcaed-9ea7-419a-b3c6-5ed0ab094d7f.png)

